### PR TITLE
Feature/reels/caching

### DIFF
--- a/app/src/main/java/com/app/reelsapp/presentation/component/CacheManager.kt
+++ b/app/src/main/java/com/app/reelsapp/presentation/component/CacheManager.kt
@@ -1,0 +1,29 @@
+package com.app.reelsapp.presentation.component
+
+import android.content.Context
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import java.io.File
+
+@UnstableApi
+object CacheManager {
+    @Volatile
+    private var simpleCache: SimpleCache? = null
+
+    fun getCache(context: Context): SimpleCache {
+        return simpleCache ?: synchronized(this) {
+            simpleCache ?: createCache(context).also { simpleCache = it }
+        }
+    }
+
+    private fun createCache(context: Context): SimpleCache {
+        val cacheDir = File(context.cacheDir, "media_cache")
+        val cacheSize = 100L * 1024L * 1024L // 100 MB
+        val evictor = LeastRecentlyUsedCacheEvictor(cacheSize)
+        val databaseProvider = StandaloneDatabaseProvider(context)
+
+        return SimpleCache(cacheDir, evictor, databaseProvider)
+    }
+}

--- a/app/src/main/java/com/app/reelsapp/presentation/component/VerticalVideoPagerWithPaging.kt
+++ b/app/src/main/java/com/app/reelsapp/presentation/component/VerticalVideoPagerWithPaging.kt
@@ -21,10 +21,6 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -38,9 +34,9 @@ fun VerticalVideoPagerWithPaging(
     modifier: Modifier = Modifier,
     productPagingItems: LazyPagingItems<Product>,
     userContentPagingItems: LazyPagingItems<UserContent>,
-    currentReelPlaying:Boolean,
+    currentReelPlaying: Boolean,
     initialPage: Int = 0,
-    onReelClick:(isPlaying:Boolean)->Unit
+    onReelClick: (isPlaying: Boolean) -> Unit
 ) {
     val pagerState = rememberPagerState(
         initialPage = initialPage,
@@ -67,9 +63,9 @@ fun VerticalVideoPagerWithPaging(
                     pagerState = pagerState,
                     pageIndex = pageIndex,
                     onSingleTap = { player ->
-                      onReelClick(!player.isPlaying)
+                        onReelClick(!player.isPlaying)
                     },
-                    onVideoDispose = { onReelClick(false)},
+                    onVideoDispose = { onReelClick(false) },
                     onVideoGoBackground = { onReelClick(false) }
                 )
 


### PR DESCRIPTION
- Integrate media caching into `ExoPlayer` using a `LeastRecentlyUsedCacheEvictor` to automatically remove the least recently accessed media when the cache size `limit` is reached.

