### PR TITLE
Refactor/exoplayer/clear cache

### DIFF
--- a/app/src/main/java/com/app/reelsapp/core/presentation/MainActivity.kt
+++ b/app/src/main/java/com/app/reelsapp/core/presentation/MainActivity.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import com.app.reelsapp.core.presentation.navigation.NavGraph
 import com.app.reelsapp.core.presentation.navigation.Routes
 import com.app.reelsapp.core.presentation.theme.ReelsAppTheme
+import com.app.reelsapp.reels.presentation.component.CacheManager
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -21,6 +24,18 @@ class MainActivity : ComponentActivity() {
                 NavGraph(Routes.Authentication)
             }
         }
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onStop() {
+        super.onStop()
+        CacheManager.release()
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun onDestroy() {
+        super.onDestroy()
+        CacheManager.clearCache(this)
     }
 }
 

--- a/app/src/main/java/com/app/reelsapp/reels/presentation/component/CacheManager.kt
+++ b/app/src/main/java/com/app/reelsapp/reels/presentation/component/CacheManager.kt
@@ -26,4 +26,17 @@ object CacheManager {
 
         return SimpleCache(cacheDir, evictor, databaseProvider)
     }
+
+    fun release() {
+        simpleCache?.release()
+        simpleCache = null
+    }
+
+    fun clearCache(context: Context) {
+        release()
+        val cacheDir = File(context.cacheDir, "media_cache")
+        if (cacheDir.exists()) {
+            cacheDir.deleteRecursively()
+        }
+    }
 }

--- a/app/src/main/java/com/app/reelsapp/reels/presentation/component/VideoPlayer.kt
+++ b/app/src/main/java/com/app/reelsapp/reels/presentation/component/VideoPlayer.kt
@@ -71,13 +71,16 @@ fun VideoPlayer(
         }
     }
 
+
+
+
     DisposableEffect(exoPlayer) {
         onDispose {
             exoPlayer.release()
             onVideoDispose()
         }
     }
-
+    
     Box(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
- Enhance `CacheManager` with cleanup and cache reset functionality.
- Release player resources when the activity `stops` and `clear` the media cache on `destroy` to free up resources and storage.